### PR TITLE
Improved implementation of the nextion upload v1.1 protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The library examples "[WifiClient](examples/WifiClient/WifiClient.ino#L128), [Ht
 </br>
 
 ## Releases
+- v0.5.0 - Improved implementation of the nextion upload v1.1 protocol
 - v0.4.0 - Fixed combatibility issues with some displays
 - v0.3.1 - Fixed typo in UploadServer example
 - v0.3.0 - ESP32 support and lots of improvements by Onno-Dirkzwager

--- a/src/ESPNexUpload.h
+++ b/src/ESPNexUpload.h
@@ -2,7 +2,17 @@
  * @file NexUpload.h
  *
  * The definition of class NexUpload. 
+ *
+ * Stability improvement, Nextion display doesn’t freeze after the seconds 4096 trance of firmware bytes. 
+ * Now the firmware upload process is stabled without the need of a hard Display power off-on intervention. 
+ * Undocumented features (not mentioned in nextion-hmi-upload-protocol-v1-1 specification) are added. 
+ * This implementation is based in on a reverse engineering with a UART logic analyser between 
+ * the Nextion editor v0.58 and a NX4024T032_011R Display.
  * 
+ * @author Machiel Mastenbroek (machiel.mastenbroek@gmail.com)
+ * @date   2019/10/25
+ * @version 0.5.0
+ *
  * Modified to work with ESP32, HardwareSerial and removed SPIFFS dependency
  * @author Onno Dirkzwager (onno.dirkzwager@gmail.com)
  * @date   2018/12/26
@@ -155,17 +165,69 @@ private: /* methods */
      *   
      * @return true if success, false for failure. 
      */
-    bool _setUploadBaudrate(uint32_t baudrate);
+    bool _setPrepareForFirmwareUpdate(uint32_t baudrate);
 
+    /*
+     * set Nextion running mode.
+     *
+	 * Undocumented feature of the Nextion protocol.
+	 * It's used by the 'upload to Nextion device' feature of the Nextion Editor V0.58
+	 * 
+	 * The nextion display doesn't send any response
+	 *
+     */
+    void _setRunningMode(void);
+
+    /*
+     * Test UART nextion connection availability 
+     *
+	 * @param input  - echo string,
+	 *
+	 * @return true when the 'echo string' that is send is equal to the received string
+	 * 
+	 * This test is used by the 'upload to Nextion device' feature of the Nextion Editor V0.58
+	 *
+     */
+    bool _echoTest(String input);
     
+    /*
+     * This function get the sleep and dim value from the Nextion display.
+     *
+	 * If sleep = 1 meaning: sleep is enabled
+     *	            action : sleep will be disabled
+	 * If dim = 0,  meaning: the display backlight is turned off
+	 *              action : dim will be set to 100 (percent)
+	 *
+     */
+    bool _handlingSleepAndDim(void);
+	
+    /*
+     * This function (debug) print the Nextion response to a human readable string
+     *
+	 * @param esp_request  - true:  request  message from esp     to nextion
+	 *                       false: response message from nextion to esp
+	 *
+	 * @param input - string to print
+	 *
+     */
+    void _printSerialData(bool esp_request, String input);
+	
+    /*
+     * This function print a prefix debug line
+	 *
+	 * @param line: optional debug/ info line
+     */
+    void _printInfoLine(String line = "");
+	
     /*
      * Send command to Nextion.
      *
-     * @param cmd - the string of command.
+     * @param cmd  - the string of command.
+	 * @param tail - end the string with tripple 0xFF byte
      *
      * @return none.
      */
-    void sendCommand(const char* cmd);
+    void sendCommand(const char* cmd, bool tail = true);
 
     /*
      * Receive string data. 


### PR DESCRIPTION
For my own project it was important that I could upload a firmware from the ESP32 to the Nextion. This because my Nextion SD slot on was fiscal no longer accessible. The ESPNexUpload is the best Nextion upload 1.1 protocol implementation on the web I could found. However, this implementation did not do the job properly. Only when the existing firmware (made with a Nextion V0.58 editor) became corrupt, and I had restarted the display (power off-on). It appears that a standard backup firmware is being activated in the Nextion Display. And that this ‘back-up?’ firmware can properly handle the upload process from the ESPNexUpload library. 

After many wanderings, I finally discovered that a firmware upload from the Nextion editor, with the intervention of a "USB to TTL" converter, to my Nextion display works flawless.  After this discovery I then monitored the serial UART traffic between the two (Editor and Display) with a Logical Analyzer. I saw that that Nextion Editor itself uses undocumented UART commands. Several passages in the Nextion Upload protocol 1.1 also suddenly became more clearer to me.

After the UART data analysis (various test setups made) I reduced what I came across to the essence, and processed it in the ESPNexUpload library. During the development of the changes and extra functionality, I continued to use the Logic Analyzer for checking. This has led, among other things, to improving the existing implementation in several places.
